### PR TITLE
added #include <algorithm> to head of 4 files

### DIFF
--- a/Pinocchio/discretization.cpp
+++ b/Pinocchio/discretization.cpp
@@ -16,6 +16,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include <algorithm>
 #include "pinocchioApi.h"
 #include "deriv.h"
 #include "debugging.h"

--- a/Pinocchio/embedding.cpp
+++ b/Pinocchio/embedding.cpp
@@ -16,6 +16,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include <algorithm>
 #include "pinocchioApi.h"
 #include "debugging.h"
 

--- a/Pinocchio/graphutils.h
+++ b/Pinocchio/graphutils.h
@@ -19,6 +19,7 @@
 #ifndef GRAPHUTILS_H_BFCF2002_4190_11E9_AA8F_EFB66606E782
 #define GRAPHUTILS_H_BFCF2002_4190_11E9_AA8F_EFB66606E782
 
+#include <algorithm>
 #include <queue>
 #include "vector.h"
 

--- a/Pinocchio/refinement.cpp
+++ b/Pinocchio/refinement.cpp
@@ -16,6 +16,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include <algorithm>
 #include "pinocchioApi.h"
 #include "deriv.h"
 #include "debugging.h"


### PR DESCRIPTION
added: ` #include <algorithm> `
to head of following files in ./Pinocchio/ : 
discretization.cpp
embedding.cpp
graphutils.h
refinement.cpp

This fixes errors thrown by gcc 14.2.1 during $make in ./OpenVSP/buildlibs/ under Arch.
